### PR TITLE
fix wrong RN version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Testing your React Native UI layouts on different screen sizes can be quite time
 
 This library aims to make this much easier by allowing the run-time switching of the main app viewport to match the sizes of different devices.
 
-> This library requires React Native 0.44.0-rc0 or above
+> This library requires React Native 0.34.0 or above.
 
 ![GIF of the library in action](docs/ScreenSwitcher.gif)
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/calvium/react-native-device-screen-switcher#readme",
   "peerDependencies": {
-    "react-native": ">=0.44.0-rc.0",
-    "react": "X"
+    "react-native": ">=0.34.0",
+    "react": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-screen-switcher",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Run app in iPhone 6 Plus simulator and auto-scale the viewport to iPhone 4, 5, and 6 sizes while running.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We need this commit:
https://github.com/facebook/react-native/commit/8451585f3861776a1d8f67b8b0dfd1e9cc705ed6

Which is in RN 0.34 (https://github.com/facebook/react-native/releases/tag/v0.34.0)