### PR TITLE
Fix for RN 0.49.0 (and bump version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Testing your React Native UI layouts on different screen sizes can be quite time
 
 This library aims to make this much easier by allowing the run-time switching of the main app viewport to match the sizes of different devices.
 
-> This library requires React Native 0.34.0 or above.
+> This library requires React Native 0.43.0 or above. For versions older versions of React Native (from 0.34.0 up), use the 0.0.4 release.
 
 ![GIF of the library in action](docs/ScreenSwitcher.gif)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-screen-switcher",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Run app in iPhone 6 Plus simulator and auto-scale the viewport to iPhone 4, 5, and 6 sizes while running.",
   "main": "index.js",
   "scripts": {},
@@ -22,8 +22,11 @@
     "url": "https://github.com/calvium/react-native-device-screen-switcher/issues"
   },
   "homepage": "https://github.com/calvium/react-native-device-screen-switcher#readme",
+  "dependencies": {
+    "prop-types": "*"
+  },
   "peerDependencies": {
-    "react-native": ">=0.34.0",
+    "react-native": ">=0.43.0",
     "react": "*"
   }
 }

--- a/src/ScreenSwitcher.js
+++ b/src/ScreenSwitcher.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component, Children} from 'react';
+import React, {Component, Children} from 'react';
+import PropTypes from 'prop-types';
 
 import {View, Dimensions, TouchableHighlight, StyleSheet, ActionSheetIOS, Text, Platform} from 'react-native';
 import deviceSizes from './deviceSizes';


### PR DESCRIPTION
Fixed PropTypes import error (which used to be a warning.)
This now requires RN 0.43.0 or newer.
There is a note to that effect in README.md.